### PR TITLE
Fix go.mod go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/Suhaibinator/computer-benchmark
 
-go 1.23.1
+go 1.23


### PR DESCRIPTION
## Summary
- update `go.mod` to specify Go 1.23
- run `go mod tidy`

## Testing
- `go mod tidy`
- `go build ./...`
