### PR TITLE
Add .gitignore for Go build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Build artifacts
+bin/
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binaries built with `go test -c`
+*.test
+
+# Output of the go coverage tool
+*.out
+
+# Dependency directories
+vendor/
+
+# Go workspace file
+go.work
+
+# Build cache directories
+pkg/


### PR DESCRIPTION
## Summary
- add `.gitignore` to ignore common Go build outputs such as `bin/`, `*.exe`, and `*.test`

## Testing
- `go vet ./...` *(fails: fmt.Println arg list ends with redundant newline)*
- `go test ./...` *(fails to build: fmt.Println arg list ends with redundant newline)*