### PR TITLE
Use int64 sizes for large benchmarks

### DIFF
--- a/multithreaded/crypto.go
+++ b/multithreaded/crypto.go
@@ -8,14 +8,14 @@ import (
 	"sync"
 )
 
-const dataSize = 3 * 1_000_000_000 // Fixed data size
+var dataSize int64 = 3 * 1_000_000_000 // Fixed data size
 
 // CryptoBenchmark performs multithreaded AES encryption
 func CryptoBenchmark() {
 	key := make([]byte, 32) // AES-256
 	rand.Read(key)
 
-	data := make([]byte, dataSize)
+	data := make([]byte, int(dataSize))
 	rand.Read(data)
 
 	block, err := aes.NewCipher(key)
@@ -26,10 +26,10 @@ func CryptoBenchmark() {
 	numWorkers := runtime.NumCPU() * 3
 	var wg sync.WaitGroup
 
-	chunkSize := dataSize / numWorkers
-	remainder := dataSize % numWorkers
+	chunkSize := int(dataSize) / numWorkers
+	remainder := int(dataSize) % numWorkers
 
-	encrypted := make([]byte, dataSize)
+	encrypted := make([]byte, int(dataSize))
 
 	startIndex := 0
 	for w := 0; w < numWorkers; w++ {
@@ -37,8 +37,8 @@ func CryptoBenchmark() {
 		if w < remainder {
 			endIndex++
 		}
-		if endIndex > dataSize {
-			endIndex = dataSize
+		if endIndex > int(dataSize) {
+			endIndex = int(dataSize)
 		}
 
 		wg.Add(1)
@@ -51,7 +51,7 @@ func CryptoBenchmark() {
 		}(startIndex, endIndex)
 
 		startIndex = endIndex
-		if startIndex >= dataSize {
+		if startIndex >= int(dataSize) {
 			break
 		}
 	}

--- a/multithreaded/memcopy.go
+++ b/multithreaded/memcopy.go
@@ -5,18 +5,18 @@ import (
 	"sync"
 )
 
-const memcopyArraySize = 1_000_000_000 // Fixed array size
+var memcopyArraySize int64 = 1_000_000_000 // Fixed array size
 
 // MemoryCopySetBenchmark performs multithreaded memory copy and set operations
 func MemoryCopySetBenchmark() {
-	src := make([]byte, memcopyArraySize)
-	dst := make([]byte, memcopyArraySize)
+	src := make([]byte, int(memcopyArraySize))
+	dst := make([]byte, int(memcopyArraySize))
 
 	numWorkers := runtime.NumCPU() * 3
 	var wg sync.WaitGroup
 
-	chunkSize := memcopyArraySize / numWorkers
-	remainder := memcopyArraySize % numWorkers
+	chunkSize := int(memcopyArraySize) / numWorkers
+	remainder := int(memcopyArraySize) % numWorkers
 
 	startIndex := 0
 	for w := 0; w < numWorkers; w++ {
@@ -24,8 +24,8 @@ func MemoryCopySetBenchmark() {
 		if w < remainder {
 			endIndex++
 		}
-		if endIndex > memcopyArraySize {
-			endIndex = memcopyArraySize
+		if endIndex > int(memcopyArraySize) {
+			endIndex = int(memcopyArraySize)
 		}
 
 		wg.Add(1)
@@ -40,7 +40,7 @@ func MemoryCopySetBenchmark() {
 		}(startIndex, endIndex)
 
 		startIndex = endIndex
-		if startIndex >= memcopyArraySize {
+		if startIndex >= int(memcopyArraySize) {
 			break
 		}
 	}

--- a/multithreaded/sorting.go
+++ b/multithreaded/sorting.go
@@ -7,11 +7,11 @@ import (
 	"sync"
 )
 
-const sortArraySize = 1_000_000_000 // Fixed array size
+var sortArraySize int64 = 1_000_000_000 // Fixed array size
 
 // SortingBenchmark performs multithreaded sorting
 func SortingBenchmark() {
-	data := make([]int, sortArraySize)
+	data := make([]int, int(sortArraySize))
 	for i := range data {
 		data[i] = rand.Int()
 	}

--- a/multithreaded/stream.go
+++ b/multithreaded/stream.go
@@ -5,19 +5,19 @@ import (
 	"sync"
 )
 
-const streamArraySize = 6 * 1_000_000_000 // Fixed array size
+var streamArraySize int64 = 6 * 1_000_000_000 // Fixed array size
 
 // StreamBenchmark performs multithreaded memory bandwidth test
 func StreamBenchmark() {
-	a := make([]float64, streamArraySize)
-	b := make([]float64, streamArraySize)
-	c := make([]float64, streamArraySize)
+	a := make([]float64, int(streamArraySize))
+	b := make([]float64, int(streamArraySize))
+	c := make([]float64, int(streamArraySize))
 
 	numWorkers := runtime.NumCPU() * 3
 	var wg sync.WaitGroup
 
-	chunkSize := streamArraySize / numWorkers
-	remainder := streamArraySize % numWorkers
+	chunkSize := int(streamArraySize) / numWorkers
+	remainder := int(streamArraySize) % numWorkers
 
 	startIndex := 0
 	for w := 0; w < numWorkers; w++ {
@@ -25,8 +25,8 @@ func StreamBenchmark() {
 		if w < remainder {
 			endIndex++
 		}
-		if endIndex > streamArraySize {
-			endIndex = streamArraySize
+		if endIndex > int(streamArraySize) {
+			endIndex = int(streamArraySize)
 		}
 
 		wg.Add(1)
@@ -44,7 +44,7 @@ func StreamBenchmark() {
 		}(startIndex, endIndex)
 
 		startIndex = endIndex
-		if startIndex >= streamArraySize {
+		if startIndex >= int(streamArraySize) {
 			break
 		}
 	}

--- a/singlethreaded/crypto.go
+++ b/singlethreaded/crypto.go
@@ -8,7 +8,8 @@ import (
 // Cryptographic Algorithm Benchmark (AES Encryption/Decryption)
 func CryptoBenchmark() {
 	key := make([]byte, 32) // 256-bit key
-	plaintext := make([]byte, 256*10000000)
+	var plaintextSize int64 = 256 * 10_000_000
+	plaintext := make([]byte, int(plaintextSize))
 
 	// Initialize key and plaintext with random data
 	_, err := rand.Read(key)

--- a/singlethreaded/memcopy.go
+++ b/singlethreaded/memcopy.go
@@ -4,9 +4,9 @@ import "crypto/rand"
 
 // Memory Copy and Set Operations Benchmark
 func MemoryCopySetBenchmark() {
-	size := 25 * 1000_000_000 // Size in bytes
-	src := make([]byte, size)
-	dst := make([]byte, size)
+	var size int64 = 25 * 1_000_000_000 // Size in bytes
+	src := make([]byte, int(size))
+	dst := make([]byte, int(size))
 
 	// Initialize source with random data
 	_, err := rand.Read(src)
@@ -18,7 +18,7 @@ func MemoryCopySetBenchmark() {
 	copy(dst, src)
 
 	// Memory Set
-	for i := 0; i < size; i++ {
+	for i := 0; i < int(size); i++ {
 		dst[i] = 0
 	}
 }

--- a/singlethreaded/sorting.go
+++ b/singlethreaded/sorting.go
@@ -4,12 +4,12 @@ import "math/rand"
 
 // Sorting Benchmark
 func SortingBenchmark() {
-	size := 1_000_000_000
-	data := make([]int, size)
+	var size int64 = 1_000_000_000
+	data := make([]int, int(size))
 
 	// Initialize array with random integers
 	for i := range data {
-		data[i] = rand.Intn(size)
+		data[i] = rand.Intn(int(size))
 	}
 
 	// Sort the array

--- a/singlethreaded/stream.go
+++ b/singlethreaded/stream.go
@@ -2,35 +2,35 @@ package singlethreaded
 
 // STREAM Benchmark
 func StreamBenchmark() {
-	size := 1000000000 // Reduced size to prevent excessive memory usage
-	a := make([]float64, size)
-	b := make([]float64, size)
-	c := make([]float64, size)
+	var size int64 = 1_000_000_000 // Reduced size to prevent excessive memory usage
+	a := make([]float64, int(size))
+	b := make([]float64, int(size))
+	c := make([]float64, int(size))
 	scalar := 3.0
 
 	// Initialize arrays
-	for i := 0; i < size; i++ {
+	for i := 0; i < int(size); i++ {
 		a[i] = 1.0
 		b[i] = 2.0
 	}
 
 	// Perform STREAM Copy
-	for i := 0; i < size; i++ {
+	for i := 0; i < int(size); i++ {
 		c[i] = a[i]
 	}
 
 	// Perform STREAM Scale
-	for i := 0; i < size; i++ {
+	for i := 0; i < int(size); i++ {
 		b[i] = scalar * c[i]
 	}
 
 	// Perform STREAM Add
-	for i := 0; i < size; i++ {
+	for i := 0; i < int(size); i++ {
 		c[i] = a[i] + b[i]
 	}
 
 	// Perform STREAM Triad
-	for i := 0; i < size; i++ {
+	for i := 0; i < int(size); i++ {
 		a[i] = b[i] + scalar*c[i]
 	}
 }


### PR DESCRIPTION
## Summary
- switch large array sizes in singlethreaded and multithreaded benchmarks to `int64`
- cast these sizes when creating slices

## Testing
- `go build ./...`
