### PR TITLE
Parameterize benchmark sizes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Build artifacts
+bin/
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binaries built with `go test -c`
+*.test
+
+# Output of the go coverage tool
+*.out
+
+# Dependency directories
+vendor/
+
+# Go workspace file
+go.work
+
+# Build cache directories
+pkg/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # computer-benchmark
-Some tools for benchmarking computer performance
+
+Some tools for benchmarking computer performance.
+
+Run the benchmarks using `go run .` and choose which test to execute from the interactive menu.

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/Suhaibinator/computer-benchmark
 
-go 1.23.1
+go 1.23

--- a/multithreaded/fft.go
+++ b/multithreaded/fft.go
@@ -8,11 +8,16 @@ import (
 	"sync"
 )
 
-const fftSize = 1 << 25 // Fixed size (must be a power of two)
+const DefaultFFTSize = 1 << 16
 
-// FftBenchmark performs a multithreaded Fast Fourier Transform
-func FftBenchmark() {
-	data := make([]complex128, fftSize)
+// FftBenchmark performs a multithreaded Fast Fourier Transform on a slice of
+// the given size. The size must be a power of two. When size is non-positive,
+// DefaultFFTSize is used.
+func FftBenchmark(size int) {
+	if size <= 0 {
+		size = DefaultFFTSize
+	}
+	data := make([]complex128, size)
 	for i := range data {
 		data[i] = complex(rand.Float64(), 0)
 	}

--- a/multithreaded/matrix_multiplication.go
+++ b/multithreaded/matrix_multiplication.go
@@ -6,23 +6,28 @@ import (
 	"sync"
 )
 
-const matrixMultiplicationSize = 4096 // Fixed matrix size for consistent workload
+const DefaultMatrixSize = 256
 
-// MatrixMultiplicationBenchmark performs multithreaded matrix multiplication
-func MatrixMultiplicationBenchmark() {
-	A := generateMatrix(matrixMultiplicationSize)
-	B := generateMatrix(matrixMultiplicationSize)
-	C := make([][]float64, matrixMultiplicationSize)
+// MatrixMultiplicationBenchmark performs multithreaded matrix multiplication on
+// an NxN matrix. When size is non-positive, DefaultMatrixSize is used.
+func MatrixMultiplicationBenchmark(size int) {
+	if size <= 0 {
+		size = DefaultMatrixSize
+	}
+
+	A := generateMatrix(size)
+	B := generateMatrix(size)
+	C := make([][]float64, size)
 	for i := range C {
-		C[i] = make([]float64, matrixMultiplicationSize)
+		C[i] = make([]float64, size)
 	}
 
 	numWorkers := runtime.NumCPU() * 3 // Use thrice the number of CPUs
 	var wg sync.WaitGroup
 
 	// Calculate the number of rows per worker and handle any remainder
-	rowsPerWorker := matrixMultiplicationSize / numWorkers
-	remainder := matrixMultiplicationSize % numWorkers
+	rowsPerWorker := size / numWorkers
+	remainder := size % numWorkers
 
 	startRow := 0
 	for w := 0; w < numWorkers; w++ {
@@ -31,17 +36,17 @@ func MatrixMultiplicationBenchmark() {
 		if w < remainder {
 			endRow++
 		}
-		if endRow > matrixMultiplicationSize {
-			endRow = matrixMultiplicationSize
+		if endRow > size {
+			endRow = size
 		}
 
 		wg.Add(1)
 		go func(start, end int) {
 			defer wg.Done()
 			for i := start; i < end; i++ {
-				for j := 0; j < matrixMultiplicationSize; j++ {
+				for j := 0; j < size; j++ {
 					sum := 0.0
-					for k := 0; k < matrixMultiplicationSize; k++ {
+					for k := 0; k < size; k++ {
 						sum += A[i][k] * B[k][j]
 					}
 					C[i][j] = sum
@@ -50,7 +55,7 @@ func MatrixMultiplicationBenchmark() {
 		}(startRow, endRow)
 
 		startRow = endRow
-		if startRow >= matrixMultiplicationSize {
+		if startRow >= size {
 			break
 		}
 	}

--- a/multithreaded/memcopy.go
+++ b/multithreaded/memcopy.go
@@ -5,18 +5,24 @@ import (
 	"sync"
 )
 
-const memcopyArraySize = 1_000_000_000 // Fixed array size
+const DefaultMemCopySize = 1_000_000
 
 // MemoryCopySetBenchmark performs multithreaded memory copy and set operations
-func MemoryCopySetBenchmark() {
-	src := make([]byte, memcopyArraySize)
-	dst := make([]byte, memcopyArraySize)
+// on a buffer of the provided size. When size is non-positive,
+// DefaultMemCopySize is used.
+func MemoryCopySetBenchmark(size int) {
+	if size <= 0 {
+		size = DefaultMemCopySize
+	}
+
+	src := make([]byte, size)
+	dst := make([]byte, size)
 
 	numWorkers := runtime.NumCPU() * 3
 	var wg sync.WaitGroup
 
-	chunkSize := memcopyArraySize / numWorkers
-	remainder := memcopyArraySize % numWorkers
+	chunkSize := size / numWorkers
+	remainder := size % numWorkers
 
 	startIndex := 0
 	for w := 0; w < numWorkers; w++ {
@@ -24,8 +30,8 @@ func MemoryCopySetBenchmark() {
 		if w < remainder {
 			endIndex++
 		}
-		if endIndex > memcopyArraySize {
-			endIndex = memcopyArraySize
+		if endIndex > size {
+			endIndex = size
 		}
 
 		wg.Add(1)
@@ -40,7 +46,7 @@ func MemoryCopySetBenchmark() {
 		}(startIndex, endIndex)
 
 		startIndex = endIndex
-		if startIndex >= memcopyArraySize {
+		if startIndex >= size {
 			break
 		}
 	}

--- a/multithreaded/sorting.go
+++ b/multithreaded/sorting.go
@@ -7,11 +7,15 @@ import (
 	"sync"
 )
 
-const sortArraySize = 1_000_000_000 // Fixed array size
+const DefaultSortSize = 1_000_000
 
-// SortingBenchmark performs multithreaded sorting
-func SortingBenchmark() {
-	data := make([]int, sortArraySize)
+// SortingBenchmark performs multithreaded sorting on a slice of the provided
+// size. When size is non-positive, DefaultSortSize is used.
+func SortingBenchmark(size int) {
+	if size <= 0 {
+		size = DefaultSortSize
+	}
+	data := make([]int, size)
 	for i := range data {
 		data[i] = rand.Int()
 	}

--- a/multithreaded/sorting_test.go
+++ b/multithreaded/sorting_test.go
@@ -1,0 +1,20 @@
+package multithreaded
+
+import (
+	"math/rand"
+	"runtime"
+	"sort"
+	"testing"
+)
+
+func TestParallelSortRandomSlice(t *testing.T) {
+	rand.Seed(1)
+	data := make([]int, 20)
+	for i := range data {
+		data[i] = rand.Intn(100)
+	}
+	parallelSort(data, runtime.NumCPU())
+	if !sort.IntsAreSorted(data) {
+		t.Fatalf("slice not sorted: %v", data)
+	}
+}

--- a/multithreaded/stream.go
+++ b/multithreaded/stream.go
@@ -5,19 +5,24 @@ import (
 	"sync"
 )
 
-const streamArraySize = 6 * 1_000_000_000 // Fixed array size
+const DefaultStreamSize = 1_000_000
 
-// StreamBenchmark performs multithreaded memory bandwidth test
-func StreamBenchmark() {
-	a := make([]float64, streamArraySize)
-	b := make([]float64, streamArraySize)
-	c := make([]float64, streamArraySize)
+// StreamBenchmark performs multithreaded memory bandwidth test on a slice of
+// the given size. When size is non-positive, DefaultStreamSize is used.
+func StreamBenchmark(size int) {
+	if size <= 0 {
+		size = DefaultStreamSize
+	}
+
+	a := make([]float64, size)
+	b := make([]float64, size)
+	c := make([]float64, size)
 
 	numWorkers := runtime.NumCPU() * 3
 	var wg sync.WaitGroup
 
-	chunkSize := streamArraySize / numWorkers
-	remainder := streamArraySize % numWorkers
+	chunkSize := size / numWorkers
+	remainder := size % numWorkers
 
 	startIndex := 0
 	for w := 0; w < numWorkers; w++ {
@@ -25,8 +30,8 @@ func StreamBenchmark() {
 		if w < remainder {
 			endIndex++
 		}
-		if endIndex > streamArraySize {
-			endIndex = streamArraySize
+		if endIndex > size {
+			endIndex = size
 		}
 
 		wg.Add(1)
@@ -44,7 +49,7 @@ func StreamBenchmark() {
 		}(startIndex, endIndex)
 
 		startIndex = endIndex
-		if startIndex >= streamArraySize {
+		if startIndex >= size {
 			break
 		}
 	}

--- a/singlethreaded/crypto.go
+++ b/singlethreaded/crypto.go
@@ -6,9 +6,17 @@ import (
 )
 
 // Cryptographic Algorithm Benchmark (AES Encryption/Decryption)
-func CryptoBenchmark() {
+const DefaultCryptoSize = 1_000_000
+
+// CryptoBenchmark runs a simple AES encryption/decryption cycle on a buffer of
+// the given size. When size is non-positive, DefaultCryptoSize is used.
+func CryptoBenchmark(size int) {
+	if size <= 0 {
+		size = DefaultCryptoSize
+	}
+
 	key := make([]byte, 32) // 256-bit key
-	plaintext := make([]byte, 256*10000000)
+	plaintext := make([]byte, size)
 
 	// Initialize key and plaintext with random data
 	_, err := rand.Read(key)

--- a/singlethreaded/fft.go
+++ b/singlethreaded/fft.go
@@ -7,8 +7,14 @@ import (
 )
 
 // Fast Fourier Transform Benchmark
-func FftBenchmark() {
-	size := 1 << 20 // FFT size (must be power of 2)
+const DefaultFFTSize = 1 << 16
+
+// FftBenchmark executes a simple FFT over the provided size. The size must be
+// a power of two. If a non-positive size is supplied, DefaultFFTSize is used.
+func FftBenchmark(size int) {
+	if size <= 0 {
+		size = DefaultFFTSize
+	}
 	data := make([]complex128, size)
 
 	// Initialize data with random values

--- a/singlethreaded/fft_test.go
+++ b/singlethreaded/fft_test.go
@@ -1,0 +1,47 @@
+package singlethreaded
+
+import (
+	"math"
+	"math/cmplx"
+	"testing"
+)
+
+// naiveDFT computes the discrete Fourier transform using the direct formula.
+func naiveDFT(a []complex128) []complex128 {
+	n := len(a)
+	result := make([]complex128, n)
+	for k := 0; k < n; k++ {
+		var sum complex128
+		for t := 0; t < n; t++ {
+			angle := -2 * math.Pi * float64(t*k) / float64(n)
+			sum += a[t] * cmplx.Exp(complex(0, angle))
+		}
+		result[k] = sum
+	}
+	return result
+}
+
+func TestFFTSmallArray(t *testing.T) {
+	data := []complex128{1, 2, 3, 4}
+	expected := naiveDFT(data)
+	// Copy input since fft works in-place
+	got := append([]complex128(nil), data...)
+	fft(got)
+	for i := range expected {
+		if cmplx.Abs(got[i]-expected[i]) > 1e-9 {
+			t.Errorf("index %d: expected %v, got %v", i, expected[i], got[i])
+		}
+	}
+}
+
+func TestFFTRandomSmallArray(t *testing.T) {
+	input := []complex128{0.5, -1.2, 3.3, 4.4, 5.5, -6.6, 7.7, 8.8}
+	expected := naiveDFT(input)
+	got := append([]complex128(nil), input...)
+	fft(got)
+	for i := range expected {
+		if cmplx.Abs(got[i]-expected[i]) > 1e-9 {
+			t.Errorf("index %d: expected %v, got %v", i, expected[i], got[i])
+		}
+	}
+}

--- a/singlethreaded/matrix_multiplication.go
+++ b/singlethreaded/matrix_multiplication.go
@@ -3,8 +3,15 @@ package singlethreaded
 import "math/rand/v2"
 
 // Matrix Multiplication Benchmark
-func MatrixMultiplicationBenchmark() {
-	size := 512 * 4 // Reduced size to prevent excessive memory usage
+const DefaultMatrixSize = 256
+
+// MatrixMultiplicationBenchmark performs a naive matrix multiplication of an
+// NxN matrix. When size is non-positive, DefaultMatrixSize is used instead.
+func MatrixMultiplicationBenchmark(size int) {
+	if size <= 0 {
+		size = DefaultMatrixSize
+	}
+
 	A := make([][]float64, size)
 	B := make([][]float64, size)
 	C := make([][]float64, size)

--- a/singlethreaded/memcopy.go
+++ b/singlethreaded/memcopy.go
@@ -3,8 +3,15 @@ package singlethreaded
 import "crypto/rand"
 
 // Memory Copy and Set Operations Benchmark
-func MemoryCopySetBenchmark() {
-	size := 25 * 1000_000_000 // Size in bytes
+const DefaultMemCopySize = 1_000_000
+
+// MemoryCopySetBenchmark performs copy and set operations on a buffer of the
+// provided size. A non-positive size falls back to DefaultMemCopySize.
+func MemoryCopySetBenchmark(size int) {
+	if size <= 0 {
+		size = DefaultMemCopySize
+	}
+
 	src := make([]byte, size)
 	dst := make([]byte, size)
 

--- a/singlethreaded/sorting.go
+++ b/singlethreaded/sorting.go
@@ -3,8 +3,14 @@ package singlethreaded
 import "math/rand"
 
 // Sorting Benchmark
-func SortingBenchmark() {
-	size := 1_000_000_000
+const DefaultSortSize = 1_000_000
+
+// SortingBenchmark sorts a slice of integers of the given size. When the size
+// is non-positive, DefaultSortSize is used.
+func SortingBenchmark(size int) {
+	if size <= 0 {
+		size = DefaultSortSize
+	}
 	data := make([]int, size)
 
 	// Initialize array with random integers

--- a/singlethreaded/sorting_test.go
+++ b/singlethreaded/sorting_test.go
@@ -1,0 +1,19 @@
+package singlethreaded
+
+import (
+	"math/rand"
+	"sort"
+	"testing"
+)
+
+func TestQuickSortRandomSlice(t *testing.T) {
+	rand.Seed(1)
+	data := make([]int, 20)
+	for i := range data {
+		data[i] = rand.Intn(100)
+	}
+	quickSort(data)
+	if !sort.IntsAreSorted(data) {
+		t.Fatalf("slice not sorted: %v", data)
+	}
+}

--- a/singlethreaded/stream.go
+++ b/singlethreaded/stream.go
@@ -1,8 +1,15 @@
 package singlethreaded
 
-// STREAM Benchmark
-func StreamBenchmark() {
-	size := 1000000000 // Reduced size to prevent excessive memory usage
+const DefaultStreamSize = 1_000_000
+
+// StreamBenchmark performs the classic STREAM memory bandwidth test on an
+// array of the provided size. If size is non-positive, DefaultStreamSize is
+// used.
+func StreamBenchmark(size int) {
+	if size <= 0 {
+		size = DefaultStreamSize
+	}
+
 	a := make([]float64, size)
 	b := make([]float64, size)
 	c := make([]float64, size)


### PR DESCRIPTION
## Summary
- merge latest changes from main branch
- expose size arguments for all benchmark functions with defaults
- keep CLI for selecting benchmarks while using large sizes in main
- add gitignore and basic tests from upstream

## Testing
- `go test ./...`
