### PR TITLE
Parameterize benchmark sizes

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,18 +26,18 @@ type Benchmark struct {
 }
 
 var benchmarkList = []Benchmark{
-	{"Matrix Multiplication", singlethreaded.MatrixMultiplicationBenchmark},
-	{"STREAM Memory Bandwidth", singlethreaded.StreamBenchmark},
-	{"Fast Fourier Transform", singlethreaded.FftBenchmark},
-	{"Memory Copy and Set", singlethreaded.MemoryCopySetBenchmark},
-	{"Sorting Algorithms", singlethreaded.SortingBenchmark},
-	{"AES Encryption/Decryption", singlethreaded.CryptoBenchmark},
-	{"Multithreaded Matrix Multiplication", multithreaded.MatrixMultiplicationBenchmark},
-	{"Multithreaded STREAM Memory Bandwidth", multithreaded.StreamBenchmark},
-	{"Multithreaded Fast Fourier Transform", multithreaded.FftBenchmark},
-	{"Multithreaded Memory Copy and Set", multithreaded.MemoryCopySetBenchmark},
-	{"Multithreaded Sorting Algorithms", multithreaded.SortingBenchmark},
-	{"Multithreaded AES Encryption", multithreaded.CryptoBenchmark},
+	{"Matrix Multiplication", func() { singlethreaded.MatrixMultiplicationBenchmark(singlethreaded.LargeMatrixMultiplicationSize) }},
+	{"STREAM Memory Bandwidth", func() { singlethreaded.StreamBenchmark(singlethreaded.LargeStreamSize) }},
+	{"Fast Fourier Transform", func() { singlethreaded.FftBenchmark(singlethreaded.LargeFFTSize) }},
+	{"Memory Copy and Set", func() { singlethreaded.MemoryCopySetBenchmark(singlethreaded.LargeMemoryCopySize) }},
+	{"Sorting Algorithms", func() { singlethreaded.SortingBenchmark(singlethreaded.LargeSortSize) }},
+	{"AES Encryption/Decryption", func() { singlethreaded.CryptoBenchmark(singlethreaded.LargePlaintextSize) }},
+	{"Multithreaded Matrix Multiplication", func() { multithreaded.MatrixMultiplicationBenchmark(multithreaded.LargeMatrixMultiplicationSize) }},
+	{"Multithreaded STREAM Memory Bandwidth", func() { multithreaded.StreamBenchmark(multithreaded.LargeStreamArraySize) }},
+	{"Multithreaded Fast Fourier Transform", func() { multithreaded.FftBenchmark(multithreaded.LargeFFTSize) }},
+	{"Multithreaded Memory Copy and Set", func() { multithreaded.MemoryCopySetBenchmark(multithreaded.LargeMemcopyArraySize) }},
+	{"Multithreaded Sorting Algorithms", func() { multithreaded.SortingBenchmark(multithreaded.LargeSortArraySize) }},
+	{"Multithreaded AES Encryption", func() { multithreaded.CryptoBenchmark(multithreaded.LargeDataSize) }},
 }
 
 func runBenchmark(name string, fn func()) BenchmarkResult {
@@ -89,10 +89,10 @@ func main() {
 		}
 
 		idx, err := strconv.Atoi(input)
-               if err != nil || idx < 1 || idx > len(benchmarkList) {
-                       fmt.Println("Invalid selection")
-                       continue
-               }
+		if err != nil || idx < 1 || idx > len(benchmarkList) {
+			fmt.Println("Invalid selection")
+			continue
+		}
 
 		b := benchmarkList[idx-1]
 		fmt.Println("Starting " + b.Name)

--- a/multithreaded/fft.go
+++ b/multithreaded/fft.go
@@ -8,11 +8,18 @@ import (
 	"sync"
 )
 
-const fftSize = 1 << 25 // Fixed size (must be a power of two)
+// LargeFFTSize sets the input length for the multithreaded FFT benchmark when
+// invoked from the command line.
+const LargeFFTSize = 1 << 25 // must be a power of two
 
 // FftBenchmark performs a multithreaded Fast Fourier Transform
-func FftBenchmark() {
-	data := make([]complex128, fftSize)
+// FftBenchmark performs a multithreaded Fast Fourier Transform over a slice of
+// the provided size. If size <= 0 a smaller power-of-two length is used.
+func FftBenchmark(size int) {
+	if size <= 0 {
+		size = 1 << 10
+	}
+	data := make([]complex128, size)
 	for i := range data {
 		data[i] = complex(rand.Float64(), 0)
 	}

--- a/multithreaded/sorting.go
+++ b/multithreaded/sorting.go
@@ -7,11 +7,17 @@ import (
 	"sync"
 )
 
-var sortArraySize int64 = 1_000_000_000 // Fixed array size
+// LargeSortArraySize is the slice length used when running the multithreaded
+// sorting benchmark from the command line.
+var LargeSortArraySize = 1_000_000_000
 
-// SortingBenchmark performs multithreaded sorting
-func SortingBenchmark() {
-	data := make([]int, int(sortArraySize))
+// SortingBenchmark performs multithreaded sorting of a slice of the given
+// length. If size <= 0 a default of one million elements is used.
+func SortingBenchmark(size int) {
+	if size <= 0 {
+		size = 1_000_000
+	}
+	data := make([]int, size)
 	for i := range data {
 		data[i] = rand.Int()
 	}

--- a/multithreaded/stream.go
+++ b/multithreaded/stream.go
@@ -5,19 +5,25 @@ import (
 	"sync"
 )
 
-var streamArraySize int64 = 6 * 1_000_000_000 // Fixed array size
+// LargeStreamArraySize defines the default workload for the multithreaded
+// StreamBenchmark when executed from the command line.
+var LargeStreamArraySize = 6 * 1_000_000_000
 
-// StreamBenchmark performs multithreaded memory bandwidth test
-func StreamBenchmark() {
-	a := make([]float64, int(streamArraySize))
-	b := make([]float64, int(streamArraySize))
-	c := make([]float64, int(streamArraySize))
+// StreamBenchmark performs a multithreaded memory bandwidth test using the
+// provided size. If size <= 0 a default of one million elements is used.
+func StreamBenchmark(size int) {
+	if size <= 0 {
+		size = 1_000_000
+	}
+	a := make([]float64, size)
+	b := make([]float64, size)
+	c := make([]float64, size)
 
 	numWorkers := runtime.NumCPU() * 3
 	var wg sync.WaitGroup
 
-	chunkSize := int(streamArraySize) / numWorkers
-	remainder := int(streamArraySize) % numWorkers
+	chunkSize := size / numWorkers
+	remainder := size % numWorkers
 
 	startIndex := 0
 	for w := 0; w < numWorkers; w++ {
@@ -25,8 +31,8 @@ func StreamBenchmark() {
 		if w < remainder {
 			endIndex++
 		}
-		if endIndex > int(streamArraySize) {
-			endIndex = int(streamArraySize)
+		if endIndex > size {
+			endIndex = size
 		}
 
 		wg.Add(1)
@@ -44,7 +50,7 @@ func StreamBenchmark() {
 		}(startIndex, endIndex)
 
 		startIndex = endIndex
-		if startIndex >= int(streamArraySize) {
+		if startIndex >= size {
 			break
 		}
 	}

--- a/singlethreaded/crypto.go
+++ b/singlethreaded/crypto.go
@@ -6,10 +6,18 @@ import (
 )
 
 // Cryptographic Algorithm Benchmark (AES Encryption/Decryption)
-func CryptoBenchmark() {
+// LargePlaintextSize configures the workload for CryptoBenchmark when executed
+// from the command line.
+var LargePlaintextSize = 256 * 10_000_000
+
+// CryptoBenchmark encrypts and decrypts a byte slice of the provided length.
+// A default of one million bytes is used if size <= 0.
+func CryptoBenchmark(size int) {
+	if size <= 0 {
+		size = 1_000_000
+	}
 	key := make([]byte, 32) // 256-bit key
-	var plaintextSize int64 = 256 * 10_000_000
-	plaintext := make([]byte, int(plaintextSize))
+	plaintext := make([]byte, size)
 
 	// Initialize key and plaintext with random data
 	_, err := rand.Read(key)

--- a/singlethreaded/fft.go
+++ b/singlethreaded/fft.go
@@ -7,8 +7,16 @@ import (
 )
 
 // Fast Fourier Transform Benchmark
-func FftBenchmark() {
-	size := 1 << 20 // FFT size (must be power of 2)
+// LargeFFTSize sets the default data length for the FftBenchmark when running
+// from the command line.
+var LargeFFTSize = 1 << 20
+
+// FftBenchmark runs a Fast Fourier Transform over a slice of the provided
+// size. If size <= 0 a small power-of-two length is chosen.
+func FftBenchmark(size int) {
+	if size <= 0 {
+		size = 1 << 10
+	}
 	data := make([]complex128, size)
 
 	// Initialize data with random values

--- a/singlethreaded/matrix_multiplication.go
+++ b/singlethreaded/matrix_multiplication.go
@@ -3,8 +3,17 @@ package singlethreaded
 import "math/rand/v2"
 
 // Matrix Multiplication Benchmark
-func MatrixMultiplicationBenchmark() {
-	size := 512 * 4 // Reduced size to prevent excessive memory usage
+// LargeMatrixMultiplicationSize controls the default workload for the
+// MatrixMultiplicationBenchmark when used from the command line.
+// Tests should supply a smaller value.
+var LargeMatrixMultiplicationSize = 512 * 4
+
+// MatrixMultiplicationBenchmark performs a simple matrix multiplication using
+// the provided matrix dimension. If size is <= 0 a small default is used.
+func MatrixMultiplicationBenchmark(size int) {
+	if size <= 0 {
+		size = 256
+	}
 	A := make([][]float64, size)
 	B := make([][]float64, size)
 	C := make([][]float64, size)

--- a/singlethreaded/memcopy.go
+++ b/singlethreaded/memcopy.go
@@ -3,10 +3,18 @@ package singlethreaded
 import "crypto/rand"
 
 // Memory Copy and Set Operations Benchmark
-func MemoryCopySetBenchmark() {
-	var size int64 = 25 * 1_000_000_000 // Size in bytes
-	src := make([]byte, int(size))
-	dst := make([]byte, int(size))
+// LargeMemoryCopySize specifies the byte count used by MemoryCopySetBenchmark
+// when run from the command line.
+var LargeMemoryCopySize = 25 * 1_000_000_000
+
+// MemoryCopySetBenchmark exercises memory copy and set operations on a slice of
+// the given size. If size <= 0 a default of one million bytes is used.
+func MemoryCopySetBenchmark(size int) {
+	if size <= 0 {
+		size = 1_000_000
+	}
+	src := make([]byte, size)
+	dst := make([]byte, size)
 
 	// Initialize source with random data
 	_, err := rand.Read(src)
@@ -18,7 +26,7 @@ func MemoryCopySetBenchmark() {
 	copy(dst, src)
 
 	// Memory Set
-	for i := 0; i < int(size); i++ {
+	for i := 0; i < size; i++ {
 		dst[i] = 0
 	}
 }

--- a/singlethreaded/sorting.go
+++ b/singlethreaded/sorting.go
@@ -3,13 +3,21 @@ package singlethreaded
 import "math/rand"
 
 // Sorting Benchmark
-func SortingBenchmark() {
-	var size int64 = 1_000_000_000
-	data := make([]int, int(size))
+// LargeSortSize indicates the number of elements used when running the sorting
+// benchmark from the command line.
+var LargeSortSize = 1_000_000_000
+
+// SortingBenchmark sorts a slice with the given length. If size <= 0 a default
+// of one million elements is used.
+func SortingBenchmark(size int) {
+	if size <= 0 {
+		size = 1_000_000
+	}
+	data := make([]int, size)
 
 	// Initialize array with random integers
 	for i := range data {
-		data[i] = rand.Intn(int(size))
+		data[i] = rand.Intn(size)
 	}
 
 	// Sort the array

--- a/singlethreaded/stream.go
+++ b/singlethreaded/stream.go
@@ -1,36 +1,43 @@
 package singlethreaded
 
-// STREAM Benchmark
-func StreamBenchmark() {
-	var size int64 = 1_000_000_000 // Reduced size to prevent excessive memory usage
-	a := make([]float64, int(size))
-	b := make([]float64, int(size))
-	c := make([]float64, int(size))
+// LargeStreamSize defines the default array length used by the
+// StreamBenchmark when executed from the command line.
+var LargeStreamSize = 1_000_000_000
+
+// StreamBenchmark performs a memory bandwidth test using the provided size.
+// If size <= 0 a modest default of one million elements is used.
+func StreamBenchmark(size int) {
+	if size <= 0 {
+		size = 1_000_000
+	}
+	a := make([]float64, size)
+	b := make([]float64, size)
+	c := make([]float64, size)
 	scalar := 3.0
 
 	// Initialize arrays
-	for i := 0; i < int(size); i++ {
+	for i := 0; i < size; i++ {
 		a[i] = 1.0
 		b[i] = 2.0
 	}
 
 	// Perform STREAM Copy
-	for i := 0; i < int(size); i++ {
+	for i := 0; i < size; i++ {
 		c[i] = a[i]
 	}
 
 	// Perform STREAM Scale
-	for i := 0; i < int(size); i++ {
+	for i := 0; i < size; i++ {
 		b[i] = scalar * c[i]
 	}
 
 	// Perform STREAM Add
-	for i := 0; i < int(size); i++ {
+	for i := 0; i < size; i++ {
 		c[i] = a[i] + b[i]
 	}
 
 	// Perform STREAM Triad
-	for i := 0; i < int(size); i++ {
+	for i := 0; i < size; i++ {
 		a[i] = b[i] + scalar*c[i]
 	}
 }


### PR DESCRIPTION
## Summary
- replace constants with exported variables and parameters
- allow benchmarks to accept custom sizes with sane defaults
- wire main benchmark menu to large default sizes

## Testing
- `go test ./...`